### PR TITLE
Validate application features against requirements

### DIFF
--- a/homepage.html
+++ b/homepage.html
@@ -1399,7 +1399,7 @@
     </div>
 
     <div id="daily-report-screen" class="container hidden">
-        <h2 style="text-align: center; margin-bottom: 30px;">דיווח חדש</h2>
+        <h2 id="report-screen-title" style="text-align: center; margin-bottom: 30px;">דיווח חדש</h2>
         <div class="toggle-btn" id="report-type-toggle">
             <div class="toggle-option active" data-type="daily">יומי</div>
             <div class="toggle-option" data-type="weekly">שבועי</div>


### PR DESCRIPTION
Fix report type conflict logic to use the selected date's week and dynamically set the report screen title.

The previous implementation incorrectly based daily/weekly report type exclusivity on the current week, leading to issues when attempting to add daily reports for past weeks. This update ensures the conflict logic correctly applies to the week of the selected report date and provides a dynamic title for editing existing reports within the current week.

---
<a href="https://cursor.com/background-agent?bcId=bc-13c192d5-351d-4abe-8125-f62e59484e90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13c192d5-351d-4abe-8125-f62e59484e90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

